### PR TITLE
Fix typescript errors in stories file

### DIFF
--- a/packages/star-ui/src/atoms/badge/badge.stories.tsx
+++ b/packages/star-ui/src/atoms/badge/badge.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Badge from './Badge';
 import Stack from '../../structures/stack/Stack';
@@ -6,7 +7,7 @@ import Stack from '../../structures/stack/Stack';
 export default {
     title: 'Badge',
     component: Badge
-};
+} as Meta;
 
 /**
  * Default badge

--- a/packages/star-ui/src/atoms/button/button.stories.tsx
+++ b/packages/star-ui/src/atoms/button/button.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Button from './Button';
 import Stack from '../../structures/stack/Stack';
@@ -6,7 +7,7 @@ import Stack from '../../structures/stack/Stack';
 export default {
     title: 'Button',
     component: Button
-};
+} as Meta;
 
 /**
  * Stories:

--- a/packages/star-ui/src/atoms/heading/heading.stories.tsx
+++ b/packages/star-ui/src/atoms/heading/heading.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Heading from './Heading';
 import { Stack } from '../../index';
@@ -6,7 +7,7 @@ import { Stack } from '../../index';
 export default {
     title: 'Heading',
     component: Heading
-};
+} as Meta;
 
 /**
  * Default heading

--- a/packages/star-ui/src/atoms/input/input.stories.tsx
+++ b/packages/star-ui/src/atoms/input/input.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Input from './Input';
 import { Stack } from '../..';
@@ -6,14 +7,14 @@ import { Stack } from '../..';
 export default {
     title: 'Input',
     component: Input
-};
+} as Meta;
 
 /**
  * Default input field
  */
 export const Default = () => {
     return (
-        <Stack style={{ width: '98%' }}>
+        <Stack>
             <Input placeholder="Sample Input" />
         </Stack>
     );
@@ -24,7 +25,7 @@ export const Default = () => {
  */
 export const Variants = () => {
     return (
-        <Stack direction="vertical" style={{ width: '98%' }}>
+        <Stack direction="vertical">
             <Input placeholder="Normal Input" />
             <Input placeholder="Disabled Input" disabled />
             <Input placeholder="Invalid Input" invalid />

--- a/packages/star-ui/src/atoms/spinner/spinner.stories.tsx
+++ b/packages/star-ui/src/atoms/spinner/spinner.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Spinner from './Spinner';
 import { Stack } from '../../structures/stack';
@@ -6,7 +7,7 @@ import { Stack } from '../../structures/stack';
 export default {
     title: 'Spinner',
     component: Spinner
-};
+} as Meta;
 
 /**
  * Stories:
@@ -24,7 +25,7 @@ export const Sizes = () => {
         <Stack>
             <Spinner size="sm" />
             <Spinner size="md" />
-            <Spinner size="bg" />
+            <Spinner size="lg" />
         </Stack>
     );
 };

--- a/packages/star-ui/src/atoms/text/text.stories.tsx
+++ b/packages/star-ui/src/atoms/text/text.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Stack from '../../structures/stack/Stack';
 import Text from './Text';
@@ -6,7 +7,7 @@ import Text from './Text';
 export default {
     title: 'Text',
     component: Text
-};
+} as Meta;
 
 /*
  *  Stories:

--- a/packages/star-ui/src/atoms/textarea/textarea.stories.tsx
+++ b/packages/star-ui/src/atoms/textarea/textarea.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import TextArea from './TextArea';
 import { Stack } from '../..';
@@ -6,14 +7,14 @@ import { Stack } from '../..';
 export default {
     title: 'TextArea',
     component: TextArea
-};
+} as Meta;
 
 /**
  * Default textarea
  */
 export const Default = () => {
     return (
-        <Stack style={{ width: '98%' }}>
+        <Stack>
             <TextArea placeholder="Sample TextArea" />
         </Stack>
     );
@@ -24,7 +25,7 @@ export const Default = () => {
  */
 export const Variants = () => {
     return (
-        <Stack direction="vertical" style={{ width: '98%' }}>
+        <Stack direction="vertical">
             <TextArea placeholder="Normal TextArea" />
             <TextArea placeholder="Disabled TextArea" disabled />
             <TextArea placeholder="Invalid TextArea" invalid />

--- a/packages/star-ui/src/molecules/card/card.stories.tsx
+++ b/packages/star-ui/src/molecules/card/card.stories.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Card from './Card';
 
 export default {
     title: 'Card',
     component: Card
-};
+} as Meta;
 
 /**
  * Stories

--- a/packages/star-ui/src/structures/stack/stack.stories.tsx
+++ b/packages/star-ui/src/structures/stack/stack.stories.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
 
 import Stack from './Stack';
 
 export default {
     title: 'Stack',
     component: Stack
-};
+} as Meta;
 
 /**
  * Default stack


### PR DESCRIPTION
Fix export default error from typescript. Fixed the issue by exporting from stories as Meta. 

Sample
```
import { Meta } from '@storybook/react/types-6-0';

export default {
    title: '<ComponentName>',
    component: <Component>
} as Meta;
```